### PR TITLE
Prevent double display of sprint info

### DIFF
--- a/jira-sprintboard-info.user.js
+++ b/jira-sprintboard-info.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         JIRA Sprintboad quick info
 // @namespace    https://github.com/m-rk/jira-tamper
-// @version      0.3
+// @version      0.4
 // @description  Adds SP and Release Version to sprint board
 // @author       Alan Seymour https://github.com/alan-seymour
 // @match        https://navitasltd.atlassian.net/secure/RapidBoard.jspa?rapidView=1*
@@ -27,14 +27,18 @@ function fetchIssues(issues) {
 }
 
 function displayData(data) {
+    // clear old info
+    $('.jira-tamper-sbi').remove();
+    
+    // display new info
     data.issues.forEach(function(issue){renderIssueDetails(issue);});
 }
 
 function renderIssueDetails(issue) {
     if(issue.fields.fixVersions.length > 0) {
-        $('.ghx-swimlane-header[data-issue-key="' + issue.key + '"]').find('.ghx-info').append('<span class="aui-label ghx-label-version ghx-label ghx-label-double" style="margin-left: 5px;">'+issue.fields.fixVersions[0].name+'</span>');
+        $('.ghx-swimlane-header[data-issue-key="' + issue.key + '"]').find('.ghx-info').append('<span class="jira-tamper-sbi aui-label ghx-label-version ghx-label ghx-label-double" style="margin-left: 5px;">'+issue.fields.fixVersions[0].name+'</span>');
     }
-    $('.ghx-swimlane-header[data-issue-key="' + issue.key + '"]').find('.ghx-heading').prepend('<span class="aui-badge ghx-statistic-badge" style="margin-right:5px;">'+issue.fields.customfield_10004+'</span>');
+    $('.ghx-swimlane-header[data-issue-key="' + issue.key + '"]').find('.ghx-heading').prepend('<span class="jira-tamper-sbi aui-badge ghx-statistic-badge" style="margin-right:5px;">'+issue.fields.customfield_10004+'</span>');
 }
 
 waitForKeyElements('.ghx-swimlane', loadExtraInfo, false);

--- a/jira-sprintboard-info.user.js
+++ b/jira-sprintboard-info.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         JIRA Sprintboad quick info
 // @namespace    https://github.com/m-rk/jira-tamper
-// @version      0.2
+// @version      0.3
 // @description  Adds SP and Release Version to sprint board
 // @author       Alan Seymour https://github.com/alan-seymour
 // @match        https://navitasltd.atlassian.net/secure/RapidBoard.jspa?rapidView=1*
@@ -21,7 +21,8 @@ function loadExtraInfo(node) {
 }
 
 function fetchIssues(issues) {
-    var issueString = issues.join(', ');
+    var filteredIssues = issues.filter((e) => { return e != '' && e != undefined && e != null; });
+    var issueString = filteredIssues.join(', ');
     $.get('https://navitasltd.atlassian.net/rest/api/2/search/', {"jql": "issue in ("+issueString+")"}, function(data){displayData(data);});
 }
 

--- a/jira-sprintboard-info.user.js
+++ b/jira-sprintboard-info.user.js
@@ -16,6 +16,7 @@ function loadExtraInfo(node) {
     if (tickets.length == $('.ghx-swimlane').length) {
         //found all tickets
         fetchIssues(tickets);
+        tickets = [];
     }
 }
 
@@ -35,7 +36,7 @@ function renderIssueDetails(issue) {
     $('.ghx-swimlane-header[data-issue-key="' + issue.key + '"]').find('.ghx-heading').prepend('<span class="aui-badge ghx-statistic-badge" style="margin-right:5px;">'+issue.fields.customfield_10004+'</span>');
 }
 
-waitForKeyElements('.ghx-swimlane', loadExtraInfo);
+waitForKeyElements('.ghx-swimlane', loadExtraInfo, false);
 
 /*--- waitForKeyElements():  A utility function, for Greasemonkey scripts,
     that detects and handles AJAXed content.

--- a/jira-sprintboard-info.user.js
+++ b/jira-sprintboard-info.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         JIRA Sprintboad quick info
 // @namespace    https://github.com/m-rk/jira-tamper
-// @version      0.1
+// @version      0.2
 // @description  Adds SP and Release Version to sprint board
 // @author       Alan Seymour https://github.com/alan-seymour
 // @match        https://navitasltd.atlassian.net/secure/RapidBoard.jspa?rapidView=1*


### PR DESCRIPTION
If the display function was triggered more than once (which jira seems to be doing now) it will now clear the existing info before displaying, rather than inserting the info twice or more.